### PR TITLE
Stop ignoring package lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ node_modules
 npm-debug.log
 .node_history
 yarn.lock
-package-lock.json
 
 ############################
 # tmp, editor & OS files


### PR DESCRIPTION
Package lock is needed to run this in runkit, and makes the project more stable.